### PR TITLE
NEXT-00000 Allow recursively overwriting sales channel / customer data

### DIFF
--- a/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
@@ -177,7 +177,7 @@ trait SalesChannelApiTestBehaviour
             $email = Uuid::randomHex() . '@example.com';
         }
 
-        $customer = array_merge([
+        $customer = array_merge_recursive([
             'id' => $customerId,
             'salesChannelId' => TestDefaults::SALES_CHANNEL,
             'defaultShippingAddress' => [
@@ -282,7 +282,7 @@ trait SalesChannelApiTestBehaviour
             $salesChannelRepository->delete([['id' => $salesChannelIds->firstId()]], Context::createDefaultContext());
         }
 
-        $salesChannel = array_merge([
+        $salesChannel = array_merge_recursive([
             'id' => $salesChannelOverride['id'] ?? Uuid::randomHex(),
             'typeId' => Defaults::SALES_CHANNEL_TYPE_STOREFRONT,
             'name' => 'API Test case sales channel',


### PR DESCRIPTION
This makes a subtle change to the create methods to be able to use them in a broader way, for example by creating saleschannels with more than one domain.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

copilot:summary

copilot:walkthrough
